### PR TITLE
Fixed popup loading non-https content and close button bug

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -36,6 +36,9 @@ for(var i = 0; i < links.length; i++) {
 	links[i].addEventListener("click", function(e) {
 		e.preventDefault();
 		var url = this.href;
+		if(location.href.indexOf("https://") >= 0 && this.href.indexOf("https://") == -1) {
+			url = url.replace("http://", "https://");
+		}
 		if(e.ctrlKey || e.metaKey){
 			window.open(url, '_new');
 		} else {
@@ -102,6 +105,7 @@ function iframeClose(){
   popupFrame.className = "";
   contentFrame.src = "";
   history.pushState({state: 1}, document.title, location.href.substring(0, location.href.indexOf("?page=")));
+  clearInterval(interval);
 }
 
 // iFrames do not work on X-Frame-Options SAMEORIGIN sites
@@ -121,14 +125,14 @@ function allowedUrl(url){
   return true;
 }
 
+var interval;
 function checkForBack() {
 	var body;
 	checked = true;
-	var interval = setInterval(function() {
+	interval = setInterval(function() {
 		body = contentFrame.contentWindow.document.querySelector("body");
 		if(popupFrame.className == "fadeIn" && (location.search.indexOf("?page=") == -1 || (location.search.replace("?page=", "") + location.hash) != contentFrame.src || (body && body.children.length == 0))) {
 			iframeClose();
-			clearInterval(interval);
 		}
 	}, 100);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",


### PR DESCRIPTION
Response to Issue #3.  For the close button, that was my mistake.  I rearranged some of the code and it now works properly (as well as the new tab button).  Along the way, I also noticed that chrome would give errors when trying to load insecure (non-https) content on secure pages (https://www.reddit.com/).  I added a small if statement to ensure consistency for all combinations of secure and non-secure pages.
