### PR TITLE
Added Timeout for popup loading time

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -42,10 +42,11 @@
   margin-right: -15px;
 }
 
-#browseButton, #closeButton {
+#buttonContainer div {
   display: inline-block;
   color: white;
   background-color: black;
+  margin-right: 2px;
   padding: 5px 10px;
   height: 18px;
   line-height: 18px;
@@ -53,8 +54,7 @@
   border-radius: 10px;
   z-index: 100000;
 }
-#browseButton { margin-right: 2px; }
-#browseButton:hover, #closeButton:hover {
+#buttonContainer div:hover {
   cursor: pointer;
   background-color: #5f99cf;
 }

--- a/inject.js
+++ b/inject.js
@@ -42,7 +42,7 @@ for(var i = 0; i < links.length; i++) {
 		e.preventDefault();
 		var url = this.href.replace(/http.?:\/\//, "//");
 		if(e.ctrlKey || e.metaKey){
-			window.open(url, '_new');
+			window.open(url, '_blank');
 		} else {
 			iframeOpen(url, this.innerHTML);
 		}
@@ -51,7 +51,8 @@ for(var i = 0; i < links.length; i++) {
 }
 
 openButton.addEventListener("mouseup", function(){
-	document.location.href = contentFrame.src;
+	clearInterval(hasClosed);
+	window.open(contentFrame.src.replace("https://", "http://"), "_self");
 });
 
 closeButton.addEventListener("mouseup", function(){
@@ -59,7 +60,7 @@ closeButton.addEventListener("mouseup", function(){
 });
 
 browseButton.addEventListener("mouseup", function(){
-	window.open(contentFrame.src, '_new');
+	window.open(contentFrame.src.replace("https://", "http://"), '_blank');
 	iframeClose();
 });
 
@@ -90,7 +91,7 @@ contentFrame.addEventListener("load", function() {
 // Open up iframe
 function iframeOpen(url, title){
   if (!allowedUrl(url)){
-     window.open(url, '_new');
+     window.open(url, '_blank');
   } else {
     // Disable page scroll
     body.style.overflow = "hidden";
@@ -104,7 +105,7 @@ function iframeOpen(url, title){
     failedToLoad = setTimeout(function() {
       contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
       if(contentFrameBody && contentFrameBody.children.length == 0) {
-        window.open(url.replace("//", "http://"), '_new');
+        window.open(url.replace("//", "http://"), '_blank');
         checked = true;
         iframeClose();
       }

--- a/inject.js
+++ b/inject.js
@@ -18,6 +18,11 @@ var buttonContainer = document.createElement("div");
 buttonContainer.id = "buttonContainer";
 popupFrame.appendChild(buttonContainer);
 
+var openButton = document.createElement("div");
+openButton.id = "openButton";
+openButton.innerHTML = "Open";
+buttonContainer.appendChild(openButton);
+
 var browseButton = document.createElement("div");
 browseButton.id = "browseButton";
 browseButton.innerHTML = "New Tab";
@@ -44,6 +49,10 @@ for(var i = 0; i < links.length; i++) {
 		return false;
 	})
 }
+
+openButton.addEventListener("mouseup", function(){
+	document.location.href = contentFrame.src;
+});
 
 closeButton.addEventListener("mouseup", function(){
 	iframeClose();

--- a/inject.js
+++ b/inject.js
@@ -28,17 +28,14 @@ closeButton.id = "closeButton";
 closeButton.innerHTML = "Close";
 buttonContainer.appendChild(closeButton);
 
-var body = document.getElementsByTagName("body")[0];
+var body = document.body;
 body.appendChild(popupFrame);
 
 var links = document.querySelectorAll("a.title");
 for(var i = 0; i < links.length; i++) {
 	links[i].addEventListener("click", function(e) {
 		e.preventDefault();
-		var url = this.href;
-		if(location.href.indexOf("https://") >= 0 && this.href.indexOf("https://") == -1) {
-			url = url.replace("http://", "https://");
-		}
+		var url = this.href.replace(/http.?:\/\//, "//");
 		if(e.ctrlKey || e.metaKey){
 			window.open(url, '_new');
 		} else {
@@ -67,16 +64,18 @@ document.querySelector("#popupFrame:not(#frameContainer)").addEventListener("mou
   iframeClose();
 });
 
-var checked = false;
+if(document.location.hash.indexOf("page=") >= 0) {
+	var url = document.location.hash.replace("#page=", "");
+	iframeOpen(url, "");
+}
+
+var checked = false, hasClosed, contentFrameBody, failedToLoad;
 contentFrame.addEventListener("load", function() {
 	contentFrame.style.display = "block";
+	clearTimeout(failedToLoad);
 	if(!checked) {
 		checkForBack();
 	}
-});
-
-contentFrame.addEventListener("unload", function() {
-	iframeClose();
 });
 
 // Open up iframe
@@ -91,8 +90,16 @@ function iframeOpen(url, title){
     contentFrame.style.display = "none";
     contentFrame.src = url;
     popupFrame.className = "fadeIn";
-    history.pushState({state: 1}, title, "?page=" + url);
+    history.pushState({state: 1}, title, "#page=" + url);
     checked = false;
+    failedToLoad = setTimeout(function() {
+      contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
+      if(contentFrameBody && contentFrameBody.children.length == 0) {
+        window.open(url.replace("//", "http://"), '_new');
+        checked = true;
+        iframeClose();
+      }
+    }, 5000);
   }
 }
 
@@ -104,8 +111,8 @@ function iframeClose(){
   // Close popup
   popupFrame.className = "";
   contentFrame.src = "";
-  history.pushState({state: 1}, document.title, location.href.substring(0, location.href.indexOf("?page=")));
-  clearInterval(interval);
+  history.pushState({state: 1}, document.title, document.location.href.substring(0, document.location.href.indexOf("#page=")));
+  clearInterval(hasClosed);
 }
 
 // iFrames do not work on X-Frame-Options SAMEORIGIN sites
@@ -125,13 +132,11 @@ function allowedUrl(url){
   return true;
 }
 
-var interval;
 function checkForBack() {
-	var body;
 	checked = true;
-	interval = setInterval(function() {
-		body = contentFrame.contentWindow.document.querySelector("body");
-		if(popupFrame.className == "fadeIn" && (location.search.indexOf("?page=") == -1 || (location.search.replace("?page=", "") + location.hash) != contentFrame.src || (body && body.children.length == 0))) {
+	hasClosed = setInterval(function() {
+		contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
+		if(popupFrame.className == "fadeIn" && (document.location.hash.indexOf("#page=") == -1 || document.location.hash.replace("#page=", "") != contentFrame.src.replace(/http.?:\/\//, "//") || (contentFrameBody && contentFrameBody.children.length == 0))) {
 			iframeClose();
 		}
 	}, 100);

--- a/inject.js
+++ b/inject.js
@@ -36,7 +36,7 @@ buttonContainer.appendChild(closeButton);
 var body = document.body;
 body.appendChild(popupFrame);
 
-var links = document.querySelectorAll("a.title");
+var links = document.querySelectorAll("a.title, a.thumbnail, .md a, a.author, .deepthread a, .pagename a, a.reddit-link-title, a.subreddit, a.comments, .domain a");
 for(var i = 0; i < links.length; i++) {
 	links[i].addEventListener("click", function(e) {
 		e.preventDefault();

--- a/loading.html
+++ b/loading.html
@@ -41,7 +41,7 @@
 	<div class="loadingContainer">
 		<span id="loadingSpinCont"><i class="fa fa-spinner fa-spin loadingSpinner"></i></span><br>
 		<span id='loadingTextCont' style="font-size: 28px; padding-bottom: 10px;">loading</span><br><br>
-		<span id="warningText">if loading takes too much time, please open this page in a new tab.</span>
+		<span id="warningText">if loading takes too much time, this page will open in a new tab.</span>
 	</div>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",


### PR DESCRIPTION
For pages that take longer than 5 seconds to load, the popup will automatically close and the link will open in a new tab.  Also added an "Open" button to open the popup page instead of the current page.  Lastly, widened the search for links to open the popup, such as author, subreddit, comments, thread, and link image.
