### PR TITLE
Special feature for when the popup loads a reddit page

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -36,19 +36,7 @@ buttonContainer.appendChild(closeButton);
 var body = document.body;
 body.appendChild(popupFrame);
 
-var links = document.querySelectorAll("a.title, a.thumbnail, .md a, a.author, .deepthread a, .pagename a, a.reddit-link-title, a.subreddit, a.comments, .domain a");
-for(var i = 0; i < links.length; i++) {
-	links[i].addEventListener("click", function(e) {
-		e.preventDefault();
-		var url = this.href.replace(/http.?:\/\//, "//");
-		if(e.ctrlKey || e.metaKey){
-			window.open(url, '_blank');
-		} else {
-			iframeOpen(url, this.innerHTML);
-		}
-		return false;
-	})
-}
+scanLinks(body);
 
 openButton.addEventListener("mouseup", function(){
 	clearInterval(hasClosed);
@@ -86,7 +74,26 @@ contentFrame.addEventListener("load", function() {
 	if(!checked) {
 		checkForBack();
 	}
+	if(this.src.indexOf(location.hostname) >= 0 && this.contentDocument.location.hostname == location.hostname) {
+		scanLinks(contentFrame.contentDocument);
+	}
 });
+
+function scanLinks(container) {
+	var links = container.querySelectorAll("a.title, a.thumbnail, .md a, a.author, .deepthread a, .pagename a, a.reddit-link-title, a.subreddit, a.comments, .domain a");
+	for(var i = 0; i < links.length; i++) {
+		links[i].addEventListener("click", function(e) {
+			e.preventDefault();
+			var url = this.href.replace(/http.?:\/\//, "//");
+			if(e.ctrlKey || e.metaKey){
+				window.open(url, '_blank');
+			} else {
+				iframeOpen(url, this.innerHTML);
+			}
+			return false;
+		})
+	}
+}
 
 // Open up iframe
 function iframeOpen(url, title){

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/updates.txt
+++ b/updates.txt
@@ -1,9 +1,27 @@
+Version 1.5.0
+If the popup loads a reddit page, all links on the popup will change the popup instead of opening in a new tab.
+
+Version 1.4.3
+Popup now defaults to opening in a new tab instead of a new window (still depends on browser settings).
+
+Version 1.4.2
+Added more selectors for links to be opened by the popup.
+
+Version 1.4.1
+Added "Open" button to open the current popup page in the same tab.
+
+Version 1.4.0
+Added check to see if the popup loads within 5 seconds.  If it doesn't, automatically open it in a new tab and close the popup.
+
+Version 1.3.4
+Fixed issues with HTTPS.
+
 Version 1.3.3
 Previously, iFrame would remember history of previous pages and going back would cycle through them.  This no longer occurs and going back will close the popup.
 
 Version 1.3.2
-Removed need for jQuery
-Downloaded waiting page for ease of access
+Removed need for jQuery.
+Downloaded waiting page for ease of access.
 
 Version 1.3.1
 Minor fixes.


### PR DESCRIPTION
If the popup loads a reddit page, all the links inside the popup will change the popup page instead of loading a new tab.  This functionality does not work outside of reddit, however, as an iframe loading up reddit cannot modify pages with a different domain (see [same-origin policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)).  Also updated the [updates.txt](https://github.com/oguzgelal/RedditPopup/blob/master/updates.txt) with all the previous version information.
