### PR TITLE
Switched from window.open to chrome.tabs.create

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -2,3 +2,9 @@ chrome.browserAction.onClicked.addListener(function(activeTab) {
     var newURL = "http://www.reddit.com";
     chrome.tabs.create({ url: newURL });
 });
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+	if(request.newTab && request.newTab.length > 0) {
+		chrome.tabs.create({url: request.newTab});
+	}
+});

--- a/inject.js
+++ b/inject.js
@@ -48,7 +48,7 @@ closeButton.addEventListener("mouseup", function(){
 });
 
 browseButton.addEventListener("mouseup", function(){
-	window.open(contentFrame.src.replace("https://", "http://"), '_blank');
+	chrome.runtime.sendMessage({newTab: contentFrame.src});
 	iframeClose();
 });
 
@@ -84,11 +84,10 @@ function scanLinks(container) {
 	for(var i = 0; i < links.length; i++) {
 		links[i].addEventListener("click", function(e) {
 			e.preventDefault();
-			var url = this.href.replace(/http.?:\/\//, "//");
 			if(e.ctrlKey || e.metaKey){
-				window.open(url, '_blank');
+				chrome.runtime.sendMessage({newTab: this.href});
 			} else {
-				iframeOpen(url, this.innerHTML);
+				iframeOpen(this.href, this.innerHTML);
 			}
 			return false;
 		})
@@ -98,21 +97,21 @@ function scanLinks(container) {
 // Open up iframe
 function iframeOpen(url, title){
   if (!allowedUrl(url)){
-     window.open(url, '_blank');
+     chrome.runtime.sendMessage({newTab: url});
   } else {
     // Disable page scroll
     body.style.overflow = "hidden";
     body.style.height = "100%";
     // Set iframe src and open popup
     contentFrame.style.display = "none";
-    contentFrame.src = url;
+    contentFrame.src = url.replace(/http.?:\/\//, "//");
     popupFrame.className = "fadeIn";
-    history.pushState({state: 1}, title, "#page=" + url);
+    history.pushState({state: 1}, title, "#page=" + url.replace(/http.?:\/\//, "//"));
     checked = false;
     failedToLoad = setTimeout(function() {
       contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
       if(contentFrameBody && contentFrameBody.children.length == 0) {
-        window.open(url.replace("//", "http://"), '_blank');
+        chrome.runtime.sendMessage({newTab: url});
         checked = true;
         iframeClose();
       }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",


### PR DESCRIPTION
With window.open, trying to open multiple pages in new tabs would override the new tab page with each successive new page, only really loading the last tab to be opened via new tab.  By using chrome.tabs.create, multiple new tabs can be opened for each page the user wishes to open.
