### PR TITLE
Fixed issue where popup instantly closes itself once opened

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -5,6 +5,6 @@ chrome.browserAction.onClicked.addListener(function(activeTab) {
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 	if(request.newTab && request.newTab.length > 0) {
-		chrome.tabs.create({url: request.newTab});
+		chrome.tabs.create({url: request.newTab, active: request.makeActiveTab});
 	}
 });

--- a/inject.js
+++ b/inject.js
@@ -152,7 +152,7 @@ function checkForBack() {
 	checked = true;
 	hasClosed = setInterval(function() {
 		contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
-		if(popupFrame.className == "fadeIn" && (document.location.hash.indexOf("#page=") == -1 || document.location.hash.replace("#page=", "") != contentFrame.src.replace(/http.?:\/\//, "//") || (contentFrameBody && contentFrameBody.children.length == 0))) {
+		if(document.location.hash.indexOf("#page=") == -1 || document.location.hash.replace("#page=", "") != contentFrame.src.replace(/http.?:\/\//, "//") || (contentFrameBody && contentFrameBody.children.length == 0)) {
 			iframeClose();
 		}
 	}, 100);

--- a/inject.js
+++ b/inject.js
@@ -48,7 +48,7 @@ closeButton.addEventListener("mouseup", function(){
 });
 
 browseButton.addEventListener("mouseup", function(){
-	chrome.runtime.sendMessage({newTab: contentFrame.src});
+	chrome.runtime.sendMessage({newTab: contentFrame.src, makeActiveTab: true});
 	iframeClose();
 });
 
@@ -85,7 +85,7 @@ function scanLinks(container) {
 		links[i].addEventListener("click", function(e) {
 			e.preventDefault();
 			if(e.ctrlKey || e.metaKey){
-				chrome.runtime.sendMessage({newTab: this.href});
+				chrome.runtime.sendMessage({newTab: this.href, makeActiveTab: false});
 			} else {
 				iframeOpen(this.href, this.innerHTML);
 			}
@@ -97,7 +97,7 @@ function scanLinks(container) {
 // Open up iframe
 function iframeOpen(url, title){
   if (!allowedUrl(url)){
-     chrome.runtime.sendMessage({newTab: url});
+     chrome.runtime.sendMessage({newTab: url, makeActiveTab: true});
   } else {
     // Disable page scroll
     body.style.overflow = "hidden";
@@ -111,7 +111,7 @@ function iframeOpen(url, title){
     failedToLoad = setTimeout(function() {
       contentFrameBody = contentFrame.contentWindow.document.querySelector("body");
       if(contentFrameBody && contentFrameBody.children.length == 0) {
-        chrome.runtime.sendMessage({newTab: url});
+        chrome.runtime.sendMessage({newTab: url, makeActiveTab: true});
         checked = true;
         iframeClose();
       }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Reddit Popup",
   "description": "This simple chrome extension lets you open Reddit links in a popup.",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "icons": {
     "16": "icon.png",
     "48": "icon.png",

--- a/updates.txt
+++ b/updates.txt
@@ -1,3 +1,9 @@
+Version 1.5.2
+Fixed issue where popup instantly closes itself once opened.
+
+Version 1.5.1
+Links from reddit can now be opened in multiple tabs.
+
 Version 1.5.0
 If the popup loads a reddit page, all links on the popup will change the popup instead of opening in a new tab.
 

--- a/updates.txt
+++ b/updates.txt
@@ -1,3 +1,6 @@
+Version 1.5.3
+Opening links with Ctrl/Cmd click will no longer make the newly opened tab the active tab.
+
 Version 1.5.2
 Fixed issue where popup instantly closes itself once opened.
 

--- a/updates.txt
+++ b/updates.txt
@@ -1,3 +1,6 @@
+Version 1.5.4
+Added check to ensure that click listeners to open the popup will never be applied to the same link twice.  Also added checking for if new elements are added and if so, add the listeners to them as well.
+
 Version 1.5.3
 Opening links with Ctrl/Cmd click will no longer make the newly opened tab the active tab.
 


### PR DESCRIPTION
In previous versions, if the user opens a popup and then immediately closes it (hitting the Close button, pressing Esc, or clicking outside the popup), any new popup opened afterwards will immediately close itself.  This issue has been fixed and popups now work correctly even if the user rapidly open and closes multiple popups.
